### PR TITLE
feat: Bump maximum python to 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Avoid writing and maintaining duplicated docstrings."
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.8, <3.12"
+requires-python = ">=3.8, <3.13"
 authors = [
     {name = "Antoine Dechaume"},
 ]
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 [project.optional-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 min_version = 4
-env_list = py{38,39,310,311}
+env_list = py{38,39,310,311,312}
 
 [testenv]
 package = wheel


### PR DESCRIPTION
Hello!  Thanks so much for making this package!

I'm playing with updating some repo's to use python3.12, and `docstring-inheritance` is one of my dependencies.

This PR bumps the maximum python to 3.12.  All tests pass with python3.12. No modification other than bumping python version in `tox.ini` and `pyproject.toml` files.

Thanks again for the great package!